### PR TITLE
Fix .bashrc snippet; Add missing pip requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ These instructions assume you already have a Raspberry Pi configured with Pi-hol
 ```
 if [ "$TERM" == "linux" ] ; then
     while :
+        do
         # Run phad in touchscreen mode (the default)
-   	    /home/pi/git/phad/phad
+        /home/pi/git/phad/phad
     
         # If you don't have a touchscreen or just want to cycle between screens every 10 seconds
         # then use this command instead:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+jinja2>==2.10
+requests>==2.19
 evdev>==1.0.0


### PR DESCRIPTION
This fixes the .bashrc error from missing `do`:
``` bash
-bash: /home/pi/.bashrc: line 123: syntax error near unexpected token `done'
-bash: /home/pi/.bashrc: line 123: `    done'
```

Additionally, it might have been me but rasbian did not have jinja2 or requests pip packages (or pip installed but that's not relevant), so I added them to the requirements.txt

Thanks for the cool tool!