### PR TITLE
If args.seconds is set, don't setup the input device

### DIFF
--- a/phad
+++ b/phad
@@ -778,12 +778,14 @@ def load_config():
 
     templates = config.get('main', 'templates').split(',')
 
-    if config.has_option('main', 'input_device'):
-        input_device = config.get('main', 'input_device')
+    if not args.seconds:
+        if config.has_option('main', 'input_device'):
+            input_device = config.get('main', 'input_device')
+        else:
+            input_device = '/dev/input/event0'
+        dev = InputDevice(input_device)
     else:
-        input_device = '/dev/input/event0'
-
-    dev = InputDevice(input_device)
+        pass
 
 #############################################################################
 


### PR DESCRIPTION
This resolves #4 -- when config is loaded if the "--seconds/-s" argument has been passed it won't setup the input device, in case it doesn't exist. This could probably support having both the touchscreen and doing a second cycle but it looks like the main method won't get that far anyways if the argument is set.