### PR TITLE
Remove OpenDNS for external IP fetch

### DIFF
--- a/phad.conf
+++ b/phad.conf
@@ -56,7 +56,7 @@ top_domains_max=20
 # URLs can be provided. Each URL will be tried in order until one
 # successfully returns an IP
 get_external_ip=True
-external_ip_url=https://diagnostic.opendns.com/myip,https://www.myexternalip.com/raw,http://ipv4bot.whatismyipaddress.com
+external_ip_url=https://www.myexternalip.com/raw,http://ipv4bot.whatismyipaddress.com
 
 # The following section defined settings for querying and toggling the
 # backlight of LCD displays


### PR DESCRIPTION
Recently OpenDNS removed the possibility to fetch someone's own raw public IP address using `https://diagnostic.opendns.com/myip`, while `diagnostic.opendns.com` asks for a login.

Instead of trying a new address, PHAD fetches the html-code of the "fake 404"-page and inserts it as public IP into `phad.dat`:
```
[...]

public_ip=<html>
 <head>
  <title>404 Not Found</title>
 </head>
 <body>
  <h1>404 Not Found</h1>
  The resource could not be found.<br /><br />



 </body>
</html>
```

As result of that, PHAD fails to get the value afterwards, throwing an ValueError and causing PHAD to close. Depending how PHAD has been added to `./bashrc`, that might causes PHAD to loop, keep crashing python and starting from a new.

```
  File "./phad", line 1128, in <module>
    data = fetch_data(config)
  File "./phad", line 783, in fetch_data
    get_timed_data(config, data)
  File "./phad", line 336, in get_timed_data
    (key, val) = chomp(line).split("=")
ValueError: not enough values to unpack (expected 2, got 1)
Exception ignored in: <function InputDevice.__del__ at 0x75cb1a08>
Traceback (most recent call last):
  File "/home/pi/.local/lib/python3.7/site-packages/evdev/device.py", line 159, in __del__
  File "/home/pi/.local/lib/python3.7/site-packages/evdev/device.py", line 304, in close
  File "/home/pi/.local/lib/python3.7/site-packages/evdev/eventio_async.py", line 54, in close
  File "/usr/lib/python3.7/asyncio/events.py", line 726, in get_event_loop_policy
  File "/usr/lib/python3.7/asyncio/events.py", line 719, in _init_event_loop_policy
ImportError: sys.meta_path is None, Python is likely shutting down
```

Obvious Fix for now is to remove the no longer functioning OpenDNS URL from `phad.conf`, yet we probably will have to look into ErrorHandling for anything other then "unavailable". In order to get PHAD back working, user also have to delete `phad.dat` manually after removing the URL as the error inside the dat-file still exists.